### PR TITLE
Use continuation passing style to decode

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -44,8 +44,7 @@
 {erl_opts, [
     debug_info,
     warn_unused_import,
-    warn_as_errors,
-    bin_opt_info
+    warn_as_errors
 ]}.
 
 {ex_doc, [
@@ -85,6 +84,14 @@
 ]}.
 
 {profiles, [
+    {analyze, [
+        {erl_opts, [
+            debug_info,
+            warn_unused_import,
+            warn_as_errors,
+            bin_opt_info
+        ]}
+    ]},
     {test, [
         {deps, [
             {meck, {git, "https://github.com/eproxus/meck.git", {tag, "0.9.2"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -45,7 +45,8 @@
 {erl_opts, [
     debug_info,
     warn_unused_import,
-    warn_as_errors
+    warn_as_errors,
+    bin_opt_info
 ]}.
 
 {ex_doc, [

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,6 @@
         {fmt, "-c"},
         xref,
         dialyzer,
-        gradualizer,
         {proper, "-c"},
         {eunit, "-c"},
         {ct, "-c"},
@@ -79,9 +78,6 @@
 
 {project_plugins, [
     {erlfmt, {git, "https://github.com/WhatsApp/erlfmt.git", {tag, "v1.0.0"}}},
-    {gradualizer,
-        {git, "https://github.com/josefs/Gradualizer.git",
-            {ref, "e226803c023bf9ceb94dfb517068208af37b9d7f"}}},
     {rebar3_proper, {git, "https://github.com/ferd/rebar3_proper.git", {tag, "0.12.1"}}},
     rebar3_hex,
     rebar3_ex_doc,

--- a/src/parthenon.erl
+++ b/src/parthenon.erl
@@ -60,8 +60,20 @@ decode(SchemaName, Binary) ->
 %% %% Register the `point' schema into the registry
 %% ok = parthenon:add_schema(point, <<"struct<x: int, y: int, z: int>">>).
 %%
+%% %% Register the `coordinates' schema into the registry
+%% ok = parthenon:add_schema(coordinates, <<"array<struct<x: int, y: int, z: int>>">>).
+%%
 %% %% Decode the `point' structure into a map with binary keys
-%% {ok, #{<<"x">> := 3, <<"y">> := 2, <<"z">> := 4}} = parthenon:decode(point, <<"{x=3, y=2, z=4}">>, [{key_format, binary}, {object_format, maps}]).
+%% {ok, #{<<"x">> := 3, <<"y">> := 2, <<"z">> := 4}} = parthenon:decode(
+%%     point, <<"{x=3, y=2, z=4}">>, [{key_format, binary}, {object_format, maps}]
+%% ),
+%%
+%% %% Decode the `coordinates' array into a list of maps with binary keys
+%% {ok, [#{<<"x">> := 3, <<"y">> := 2, <<"z">> := 4}, #{<<"x">> := 5, <<"y">> := 6, <<"z">> := 7}]} = parthenon:decode(
+%%      coordinates, <<"[{x=3, y=2, z=4}, {x=5, y=6, z=7}]">>, [
+%%          {key_format, binary}, {object_format, maps}
+%%      ]
+%%  ),
 %% '''
 %% @end
 decode(SchemaName, Binary, Options) ->

--- a/src/parthenon.erl
+++ b/src/parthenon.erl
@@ -21,7 +21,8 @@
 add_schema(SchemaName, RawSchema) ->
     parthenon_schema_server:add_schema(SchemaName, RawSchema).
 
--spec decode(SchemaName :: atom(), Binary :: binary()) -> {ok, term()} | {error, term()}.
+-spec decode(SchemaName :: atom(), Binary :: binary()) ->
+    {ok, parthenon_decode:value()} | {error, term()}.
 %% @doc
 %% Parse the raw Athena structure with the specified schema.
 %% @end
@@ -29,7 +30,7 @@ decode(SchemaName, Binary) ->
     parthenon_decode:try_decode(SchemaName, Binary).
 
 -spec decode(SchemaName :: atom(), Binary :: binary(), Options :: [parthenon_decode:option()]) ->
-    {ok, term()} | {error, term()}.
+    {ok, parthenon_decode:value()} | {error, term()}.
 %% @doc
 %% Parse the raw Athena structure with the specified schema and apply the
 %% specified options.

--- a/src/parthenon_decode.erl
+++ b/src/parthenon_decode.erl
@@ -181,7 +181,7 @@ to_key(Key, #decode_options{key_format = atom}) when is_binary(Key) ->
 to_key(Key, #decode_options{key_format = existing_atom}) when is_binary(Key) ->
     to_existing_atom(Key);
 to_key(Key, _) ->
-    trim(Key).
+    Key.
 
 to_existing_atom(Raw) ->
     Binary = trim(Raw),

--- a/src/parthenon_decode.erl
+++ b/src/parthenon_decode.erl
@@ -112,8 +112,8 @@ object_value(<<Character, Rest/binary>>, Key, LastComma, Buffer, Object, Nexts, 
 list(<<$], Rest/binary>>, List, _Buffer, Nexts, {map_array, _}, _Options) ->
     next(Rest, lists:reverse(List), Nexts);
 list(<<$], Rest/binary>>, List, Buffer, Nexts, Encoder, _Options) ->
-    NewList = lists:reverse([Buffer | List]),
-    next(Rest, Encoder(NewList), Nexts);
+    NewList = lists:reverse([Encoder(Buffer) | List]),
+    next(Rest, NewList, Nexts);
 list(<<${, Rest/binary>>, List, _Buffer, Nexts, {map_array, Encoder}, Options) ->
     Next = {list, List, {map_array, Encoder}, Options},
     object(Rest, make_object(Options), [Next | Nexts], Encoder, Options);
@@ -121,7 +121,7 @@ list(<<$,, Rest/binary>>, List, _Buffer, Nexts, Encoder = {map_array, _}, Option
     Next = {list, List, Encoder, Options},
     whitespace(Rest, Next, Nexts);
 list(<<$,, Rest/binary>>, List, Buffer, Nexts, Encoder, Options) ->
-    Next = {list, [Buffer | List], Encoder, Options},
+    Next = {list, [Encoder(Buffer) | List], Encoder, Options},
     whitespace(Rest, Next, Nexts);
 list(<<Character, Rest/binary>>, List, Buffer, Nexts, Encoder, Options) ->
     list(Rest, List, <<Buffer/binary, Character>>, Nexts, Encoder, Options).

--- a/src/parthenon_decode.erl
+++ b/src/parthenon_decode.erl
@@ -38,7 +38,10 @@
     {object, Key :: binary(), object(), schema(), decode_options()}
     | {list, array(), schema(), decode_options()}.
 
--export_type([option/0]).
+-export_type([
+    option/0,
+    value/0
+]).
 
 %%%===================================================================
 %%% API

--- a/src/parthenon_schema.erl
+++ b/src/parthenon_schema.erl
@@ -3,7 +3,7 @@
 %% API
 -export([create/1]).
 
--type schema() :: encoder() | schema_object().
+-type schema() :: schema_value().
 -type schema_object() :: #{schema_key() := schema_value()}.
 -type schema_key() :: atom().
 -type schema_value() :: encoder() | schema_object() | {map_array, schema()}.
@@ -43,5 +43,5 @@ create(RawSchema) ->
 -spec ensure_string(binary() | string()) -> string().
 ensure_string(Binary) when is_binary(Binary) ->
     binary_to_list(Binary);
-ensure_string(String) ->
+ensure_string(String) when is_list(String) ->
     String.

--- a/src/parthenon_schema_parser.yrl
+++ b/src/parthenon_schema_parser.yrl
@@ -39,8 +39,7 @@ create_encoder({encoding, _Line, Encoding}) ->
 create_encoder({list, Encoder}) when is_map(Encoder) ->
     {map_array, Encoder};
 create_encoder({list, Encoder}) ->
-    ListEncoder = fun(List) -> lists:map(Encoder, List) end,
-    with_null_as_undefined(ListEncoder);
+    with_null_as_undefined(Encoder);
 create_encoder(Unknown) ->
     throw({unknown_encoding, Unknown}).
 

--- a/test/parthenon_decode_SUITE.erl
+++ b/test/parthenon_decode_SUITE.erl
@@ -151,7 +151,7 @@ can_handle_spaces_in_values(_Config) ->
         ]},
         parthenon_decode:try_decode(
             ?A_SCHEMA_NAME,
-            <<"{a = 123, b = foo bar , c={d = 1011 ,f=[ foo bar, baz bar]},e=[ 456, 789 ]}">>,
+            <<"{\n\ta = 123,\n\tb = foo bar ,\n\t c = {\n\t\td = 1011 ,\n\t\tf = [ foo bar,\n baz bar ] } ,\n\t e = [ 456, 789 ] } ">>,
             [{object_format, proplists}]
         )
     ).

--- a/test/parthenon_schema_SUITE.erl
+++ b/test/parthenon_schema_SUITE.erl
@@ -95,13 +95,13 @@ contain_correct_encoder(_Config) ->
     ?assertEqual(1.0, apply_encoder(<<"double_">>, <<"1.0">>, Schema)),
     ?assertEqual(100, apply_encoder(<<"big_integer">>, <<"100">>, Schema)),
     ?assertEqual(<<"test">>, apply_encoder(<<"string_">>, <<"test">>, Schema)),
-    ?assertEqual([2], apply_encoder(<<"integer_list">>, [<<"2">>], Schema)),
+    ?assertEqual([2], apply_list_encoder(<<"integer_list">>, [<<"2">>], Schema)),
     ?assertEqual(
-        [true, false], apply_encoder(<<"boolean_list">>, [<<"true">>, <<"false">>], Schema)
+        [true, false], apply_list_encoder(<<"boolean_list">>, [<<"true">>, <<"false">>], Schema)
     ),
-    ?assertEqual([2.0], apply_encoder(<<"double_list">>, [<<"2.0">>], Schema)),
-    ?assertEqual([101], apply_encoder(<<"big_integer_list">>, [<<"101">>], Schema)),
-    ?assertEqual([<<"test_2">>], apply_encoder(<<"string_list">>, [<<"test_2">>], Schema)).
+    ?assertEqual([2.0], apply_list_encoder(<<"double_list">>, [<<"2.0">>], Schema)),
+    ?assertEqual([101], apply_list_encoder(<<"big_integer_list">>, [<<"101">>], Schema)),
+    ?assertEqual([<<"test_2">>], apply_list_encoder(<<"string_list">>, [<<"test_2">>], Schema)).
 
 can_parse_complex_schema(Config) ->
     ?assertMatch({ok, _}, parthenon_schema:create(?config(raw_schema, Config))).
@@ -120,15 +120,14 @@ return_undefined_on_null_values(_Config) ->
     ?assertEqual(undefined, apply_encoder(<<"double_">>, <<"null">>, Schema)),
     ?assertEqual(undefined, apply_encoder(<<"big_integer">>, <<"null">>, Schema)),
     ?assertEqual(undefined, apply_encoder(<<"string_">>, <<"null">>, Schema)),
-    ?assertEqual(undefined, apply_encoder(<<"integer_list">>, <<"null">>, Schema)),
-    ?assertEqual([undefined], apply_encoder(<<"integer_list">>, [<<"null">>], Schema)),
+    ?assertEqual([undefined], apply_list_encoder(<<"integer_list">>, [<<"null">>], Schema)),
     ?assertEqual(
         [undefined, undefined],
-        apply_encoder(<<"boolean_list">>, [<<"null">>, <<"null">>], Schema)
+        apply_list_encoder(<<"boolean_list">>, [<<"null">>, <<"null">>], Schema)
     ),
-    ?assertEqual([undefined], apply_encoder(<<"double_list">>, [<<"null">>], Schema)),
-    ?assertEqual([undefined], apply_encoder(<<"big_integer_list">>, [<<"null">>], Schema)),
-    ?assertEqual([undefined], apply_encoder(<<"string_list">>, [<<"null">>], Schema)).
+    ?assertEqual([undefined], apply_list_encoder(<<"double_list">>, [<<"null">>], Schema)),
+    ?assertEqual([undefined], apply_list_encoder(<<"big_integer_list">>, [<<"null">>], Schema)),
+    ?assertEqual([undefined], apply_list_encoder(<<"string_list">>, [<<"null">>], Schema)).
 
 %%%===================================================================
 %%% Internal functions
@@ -137,3 +136,7 @@ return_undefined_on_null_values(_Config) ->
 apply_encoder(Field, Value, Schema) ->
     Encoder = maps:get(Field, Schema),
     Encoder(Value).
+
+apply_list_encoder(Field, Value, Schema) ->
+    Encoder = maps:get(Field, Schema),
+    [Encoder(V) || V <- Value].


### PR DESCRIPTION
Use continuation passing style to prevent binaries from being copied and to be able to reuse match context.

See #15 